### PR TITLE
💄 各カテゴリに紐づく記事一覧画面のコンポーネントを静的に作成

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { MantineProvider } from '@mantine/core';
 import React from 'react';
 
 import MainLayout from './components/Layout/MainLayout';
-import FilterableArticleItems from './features/articles/FilterableArticleItems';
+import CategoryFilterableArticleItems from './features/articles/CategoryFilterableArticleItems';
 
 const App = () => {
   return (
@@ -16,8 +16,12 @@ const App = () => {
         <FilterableCategoryItems />
       </MainLayout> */}
 
-      <MainLayout>
+      {/* <MainLayout>
         <FilterableArticleItems />
+      </MainLayout> */}
+
+      <MainLayout>
+        <CategoryFilterableArticleItems />
       </MainLayout>
       {/* <SearchInput />
       <ArticleItem {...articleItem} />

--- a/src/features/articles/CategoryArticlesHeader.tsx
+++ b/src/features/articles/CategoryArticlesHeader.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable react/no-unescaped-entities */
+import { Group, Text } from '@mantine/core';
+import React from 'react';
+
+import { ReactComponent as RailsSVG } from '/src/rubyonrails.svg';
+
+const CategoryArticlesHeader = () => {
+  return (
+    <Group spacing="lg" className="xs:px-3 sm:px-5">
+      <RailsSVG className="h-20 sm:h-24" />
+      <Text className="font-bold sm:text-2xl">"Ruby on Rails"に関する記事</Text>
+    </Group>
+  );
+};
+
+export default CategoryArticlesHeader;

--- a/src/features/articles/CategoryFilterableArticleItems.tsx
+++ b/src/features/articles/CategoryFilterableArticleItems.tsx
@@ -1,0 +1,20 @@
+import { Space } from '@mantine/core';
+import React from 'react';
+
+import SearchInput from '../../components/SearchInput';
+import ArticleItems from './ArticleItems';
+import CategoryArticlesHeader from './CategoryArticlesHeader';
+
+const CategoryFilterableArticleItems = () => {
+  return (
+    <>
+      <CategoryArticlesHeader />
+      <Space h="lg" />
+      <SearchInput />
+      <Space h="lg" />
+      <ArticleItems />
+    </>
+  );
+};
+
+export default CategoryFilterableArticleItems;


### PR DESCRIPTION
## Issue

#18 

## 変更の概要

- 各カテゴリに紐づく記事一覧画面のコンポーネントをstateを用いず、静的に作成
