### PR TITLE
🚨categorySliceのstoreで管理するstateの型を再定義

### DIFF
--- a/src/store/ducks/categorySlice.ts
+++ b/src/store/ducks/categorySlice.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Category } from '../../features/categories/types';
 import { RootState } from '../store';
 
-const initialState: Category = {
+const initialState: Pick<Category, 'Icon' | 'title'> = {
   title: '',
   Icon: null,
 };


### PR DESCRIPTION
## Issue

#46 

## 変更の概要

categorySliceのstoreで管理するグローバルstateの型を定義し直す
