### PR TITLE
ルーティング処理を修正してページネーションの挙動を変更＋コメントボタンを設置

### DIFF
--- a/src/components/HeaderAction.tsx
+++ b/src/components/HeaderAction.tsx
@@ -245,7 +245,7 @@ const HeaderAction = ({ isLogin, links }: HeaderActionProps) => {
                 <Menu.Dropdown>
                   <Menu.Item
                     className="px-0"
-                    onClick={() => navigate('/dashboards')}
+                    onClick={() => navigate('/dashboards/all')}
                   >
                     <Menu.Label className="text-sm">
                       {currentUser.nickname}
@@ -254,13 +254,13 @@ const HeaderAction = ({ isLogin, links }: HeaderActionProps) => {
                   <Menu.Divider />
                   <Menu.Item
                     icon={<IconHeart size={14} stroke={1.5} />}
-                    onClick={() => navigate('/dashboards?tab=likes')}
+                    onClick={() => navigate('/dashboards/likes')}
                   >
                     いいねした記事
                   </Menu.Item>
                   <Menu.Item
                     icon={<IconBookmark size={14} stroke={1.5} />}
-                    onClick={() => navigate('/dashboards?tab=bookmarks')}
+                    onClick={() => navigate('/dashboards/bookmarks')}
                   >
                     ブックマークした記事
                   </Menu.Item>

--- a/src/components/NotFoundTitle.tsx
+++ b/src/components/NotFoundTitle.tsx
@@ -7,6 +7,7 @@ import {
   Title,
 } from '@mantine/core';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const useStyles = createStyles((theme) => ({
   root: {
@@ -51,6 +52,7 @@ const useStyles = createStyles((theme) => ({
 
 const NotFoundTitle = () => {
   const { classes } = useStyles();
+  const navigate = useNavigate();
 
   return (
     <Container className={classes.root}>
@@ -66,7 +68,7 @@ const NotFoundTitle = () => {
         address, or the page has been moved to another URL.
       </Text>
       <Group position="center">
-        <Button variant="subtle" size="md">
+        <Button variant="subtle" size="md" onClick={() => navigate('/')}>
           Take me back to home page
         </Button>
       </Group>

--- a/src/features/articles/components/ArticleDetail.tsx
+++ b/src/features/articles/components/ArticleDetail.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import { IconBookmark, IconHeart, IconShare } from '@tabler/icons';
+import { IconBookmark, IconHeart, IconMessageCircle2 } from '@tabler/icons';
 import { deleteBookmark } from 'articles/api/deleteBookmark';
 import { deleteLike } from 'articles/api/deleteLike';
 import { postBookmarks } from 'articles/api/postBookmarks';
@@ -150,9 +150,6 @@ const ArticleDetail = ({
     <Card
       radius="md"
       className="hover:bg-m_gray-1 bg-m_gray-0 max-w-md py-0 hover:cursor-pointer"
-      // component="a"
-      // href="https://zenn.dev/"
-      // target="_blank"
     >
       <Stack>
         <div className="pt-4">
@@ -168,7 +165,7 @@ const ArticleDetail = ({
                 color="dimmed"
                 weight={700}
                 size="xs"
-                onClick={() => navigate(`/categories/${category.path}`)}
+                onClick={() => navigate(`/categories/${category.path}/all`)}
               >
                 #{category.title}
               </Anchor>
@@ -185,9 +182,6 @@ const ArticleDetail = ({
           </Anchor>
           <Group noWrap spacing="xs" className="mt-2 justify-between">
             <Group spacing="xs" noWrap>
-              {/* <ActionIcon size="md">
-                <Zenn style={{ color: '#3EA8FF' }} />
-              </ActionIcon> */}
               <Image src={media.image} fit="contain" width={20} />
               <Text size="xs">{media.name}</Text>
               <Text size="xs" color="dimmed">
@@ -240,11 +234,7 @@ const ArticleDetail = ({
                 </ActionIcon>
               )}
               <ActionIcon>
-                <IconShare
-                  size={16}
-                  color={theme.colors.blue[6]}
-                  stroke={1.5}
-                />
+                <IconMessageCircle2 size={16} stroke={1.5} />
               </ActionIcon>
             </Group>
           </Group>

--- a/src/features/articles/components/ArticleItem.tsx
+++ b/src/features/articles/components/ArticleItem.tsx
@@ -9,7 +9,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import { IconBookmark, IconHeart, IconShare } from '@tabler/icons';
+import { IconBookmark, IconHeart, IconMessageCircle2 } from '@tabler/icons';
 import { deleteBookmark } from 'articles/api/deleteBookmark';
 import { deleteLike } from 'articles/api/deleteLike';
 import { postBookmarks } from 'articles/api/postBookmarks';
@@ -166,7 +166,7 @@ const ArticleItem = ({
                 color="dimmed"
                 weight={700}
                 className={classes.category}
-                onClick={() => navigate(`/categories/${category.path}`)}
+                onClick={() => navigate(`/categories/${category.path}/all`)}
               >
                 #{category.title}
               </Anchor>
@@ -241,66 +241,11 @@ const ArticleItem = ({
               </ActionIcon>
             )}
             <ActionIcon>
-              <IconShare size={16} color={theme.colors.blue[6]} stroke={1.5} />
+              <IconMessageCircle2 size={16} stroke={1.5} />
             </ActionIcon>
           </Group>
         </Group>
       </Stack>
-      {/* <Group noWrap spacing={3} className="py-3">
-        <Stack justify="space-between" spacing="xs">
-          <div className="xs:space-x-2 flex space-x-1">
-            {categories.map((category) => (
-              <Anchor
-                key={category.title}
-                color="dimmed"
-                weight={700}
-                className={classes.category}
-                onClick={() => navigate(`/categories/${category.path}`)}
-              >
-                #{category.title}
-              </Anchor>
-            ))}
-          </div>
-          <Anchor
-            className="text-sm font-bold leading-tight text-black"
-            href="https://zenn.dev/"
-            target="_blank"
-          >
-            {title}
-          </Anchor>
-          <Group noWrap spacing="xs">
-            <Group spacing="xs" noWrap>
-              <ActionIcon size="md">
-                <Zenn style={{ color: '#3EA8FF' }} />
-              </ActionIcon>
-              <Text size="xs">{media}</Text>
-            </Group>
-          </Group>
-        </Stack>
-        <Stack justify="space-between" spacing="xs">
-          <Text size="xs" color="dimmed">
-            {date}
-          </Text>
-          <a href="https://zenn.dev/" target="_blank" rel="noreferrer">
-            <Image src={image} width={150} fit="contain" />
-          </a>
-          <Group className="justify-between px-2">
-            <ActionIcon>
-              <IconHeart size={18} color={theme.colors.red[6]} stroke={1.5} />
-            </ActionIcon>
-            <ActionIcon>
-              <IconBookmark
-                size={18}
-                color={theme.colors.yellow[6]}
-                stroke={1.5}
-              />
-            </ActionIcon>
-            <ActionIcon>
-              <IconShare size={16} color={theme.colors.blue[6]} stroke={1.5} />
-            </ActionIcon>
-          </Group>
-        </Stack>
-      </Group> */}
     </Card>
   );
 };

--- a/src/features/articles/components/ArticleLists.tsx
+++ b/src/features/articles/components/ArticleLists.tsx
@@ -8,7 +8,12 @@ import {
   Tabs,
 } from '@mantine/core';
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
 
 import { useMediaQuery } from '../../../lib/mantine/useMediaQuery';
 import { ArticleListsProps } from '../types';
@@ -23,14 +28,13 @@ const ArticleLists = ({
   articleItems,
   filterInput,
   isLoading,
-  page,
-  setPage,
 }: ArticleListsProps) => {
   const largerThanSm = useMediaQuery('sm');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const articleGenre = searchParams.get('tab') || 'all';
+  const articlePage = parseInt(searchParams.get('page') || '1');
   const { hash, pathname } = useLocation();
+  const params = useParams();
 
   const [currentArticleItems, setCurrentArticleItems] = useState(
     articleItems.slice(0, ITEMS_PAGE_SIZE)
@@ -49,33 +53,22 @@ const ArticleLists = ({
     const filterArticleItems = articleItems.filter((articleItem) =>
       new RegExp(filterInput, 'i').test(articleItem.title)
     );
-    const from = (page - 1) * ITEMS_PAGE_SIZE;
+    const from = (articlePage - 1) * ITEMS_PAGE_SIZE;
     const to = from + ITEMS_PAGE_SIZE;
     setCurrentArticleItems(filterArticleItems.slice(from, to));
-  }, [page, articleItems, filterInput, hash, pathname]);
+  }, [articlePage, articleItems, filterInput, hash]);
 
   return (
     <Card radius="md">
-      <Tabs value={articleGenre}>
+      <Tabs
+        value={params.tab}
+        onTabChange={(value) => {
+          navigate(`/articles/${value}`);
+        }}
+      >
         <Tabs.List className="flex justify-around">
-          <Tabs.Tab
-            value="all"
-            onClick={() => {
-              setPage(1);
-              navigate(pathname);
-            }}
-          >
-            {leftGenre}
-          </Tabs.Tab>
-          <Tabs.Tab
-            value="popular"
-            onClick={() => {
-              setPage(1);
-              navigate(`${pathname}?tab=popular`);
-            }}
-          >
-            {rightGenre}
-          </Tabs.Tab>
+          <Tabs.Tab value="all">{leftGenre}</Tabs.Tab>
+          <Tabs.Tab value="popular">{rightGenre}</Tabs.Tab>
         </Tabs.List>
       </Tabs>
       {isLoading ? (
@@ -94,7 +87,13 @@ const ArticleLists = ({
             })}
           </SimpleGrid>
           <Card className="mt-10 flex items-center justify-center">
-            <Pagination total={pageCount} onChange={setPage} page={page} />
+            <Pagination
+              total={pageCount}
+              onChange={(nextPage) => {
+                navigate(`${pathname}?page=${nextPage}`);
+              }}
+              page={articlePage}
+            />
           </Card>
         </>
       ) : (
@@ -108,7 +107,13 @@ const ArticleLists = ({
             ))}
           </SimpleGrid>
           <Card className="mt-10 flex items-center justify-center">
-            <Pagination total={pageCount} onChange={setPage} page={page} />
+            <Pagination
+              total={pageCount}
+              onChange={(nextPage) => {
+                navigate(`${pathname}?page=${nextPage}`);
+              }}
+              page={articlePage}
+            />
           </Card>
         </>
       )}

--- a/src/features/articles/components/CategoryArticleLists.tsx
+++ b/src/features/articles/components/CategoryArticleLists.tsx
@@ -1,0 +1,124 @@
+/* eslint-disable tailwindcss/no-custom-classname */
+import {
+  Card,
+  Center,
+  Loader,
+  Pagination,
+  SimpleGrid,
+  Tabs,
+} from '@mantine/core';
+import React, { useEffect, useState } from 'react';
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
+
+import { useMediaQuery } from '../../../lib/mantine/useMediaQuery';
+import { ArticleListsProps } from '../types';
+import ArticleDetail from './ArticleDetail';
+import ArticleItem from './ArticleItem';
+
+const ITEMS_PAGE_SIZE = 10;
+
+const CategoryArticleLists = ({
+  leftGenre,
+  rightGenre,
+  articleItems,
+  filterInput,
+  isLoading,
+}: ArticleListsProps) => {
+  const largerThanSm = useMediaQuery('sm');
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const articlePage = parseInt(searchParams.get('page') || '1');
+  const { hash, pathname } = useLocation();
+  const params = useParams();
+
+  const [currentArticleItems, setCurrentArticleItems] = useState(
+    articleItems.slice(0, ITEMS_PAGE_SIZE)
+  );
+
+  const pageCount = Math.ceil(
+    articleItems.filter((articleItem) =>
+      new RegExp(filterInput, 'i').test(articleItem.title)
+    ).length / ITEMS_PAGE_SIZE
+  );
+
+  useEffect(() => {
+    if (!hash) {
+      window.scrollTo(0, 0);
+    }
+    const filterArticleItems = articleItems.filter((articleItem) =>
+      new RegExp(filterInput, 'i').test(articleItem.title)
+    );
+    const from = (articlePage - 1) * ITEMS_PAGE_SIZE;
+    const to = from + ITEMS_PAGE_SIZE;
+    setCurrentArticleItems(filterArticleItems.slice(from, to));
+  }, [articlePage, articleItems, filterInput, hash]);
+
+  return (
+    <Card radius="md">
+      <Tabs
+        value={params.tab}
+        onTabChange={(value) => {
+          navigate(`/categories/${params.categoryName}/${value}`);
+        }}
+      >
+        <Tabs.List className="flex justify-around">
+          <Tabs.Tab value="all">{leftGenre}</Tabs.Tab>
+          <Tabs.Tab value="popular">{rightGenre}</Tabs.Tab>
+        </Tabs.List>
+      </Tabs>
+      {isLoading ? (
+        <Center className="py-20">
+          <Loader />
+        </Center>
+      ) : largerThanSm ? (
+        <>
+          <SimpleGrid mt="md" className="grid-cols-2">
+            {currentArticleItems.map((articleItem, index) => {
+              if (index < 2) {
+                return <ArticleDetail key={articleItem.id} {...articleItem} />;
+              } else {
+                return <ArticleItem key={articleItem.id} {...articleItem} />;
+              }
+            })}
+          </SimpleGrid>
+          <Card className="mt-10 flex items-center justify-center">
+            <Pagination
+              total={pageCount}
+              onChange={(nextPage) => {
+                navigate(`${pathname}?page=${nextPage}`);
+              }}
+              page={articlePage}
+            />
+          </Card>
+        </>
+      ) : (
+        <>
+          <SimpleGrid
+            my="md"
+            className="mx-auto grid-cols-1 place-items-center"
+          >
+            {currentArticleItems.map((articleItem) => (
+              <ArticleItem key={articleItem.id} {...articleItem} />
+            ))}
+          </SimpleGrid>
+          <Card className="mt-10 flex items-center justify-center">
+            <Pagination
+              total={pageCount}
+              onChange={(nextPage) => {
+                navigate(`${pathname}?page=${nextPage}`);
+              }}
+              page={articlePage}
+            />
+          </Card>
+        </>
+      )}
+    </Card>
+  );
+};
+
+export default CategoryArticleLists;

--- a/src/features/articles/components/TrendArticleLists.tsx
+++ b/src/features/articles/components/TrendArticleLists.tsx
@@ -31,7 +31,7 @@ const TrendArticleLists = ({
         <Anchor
           size="sm"
           className="leading-none"
-          onClick={() => navigate('/articles')}
+          onClick={() => navigate('/articles/all')}
         >
           すべての記事を見る
         </Anchor>
@@ -60,7 +60,7 @@ const TrendArticleLists = ({
       <Card
         className="hover:bg-m_gray-0 mt-3 flex items-center justify-center border-x-0 py-2 font-semibold hover:cursor-pointer"
         withBorder
-        onClick={() => navigate('/articles')}
+        onClick={() => navigate('/articles/all')}
       >
         すべての記事を見る
       </Card>

--- a/src/features/articles/containers/CategoryFilterableArticles.tsx
+++ b/src/features/articles/containers/CategoryFilterableArticles.tsx
@@ -1,14 +1,15 @@
 import { Space, TextInput } from '@mantine/core';
 import { IconSearch } from '@tabler/icons';
-import ArticleLists from 'articles/components/ArticleLists';
+import CategoryArticleLists from 'articles/components/CategoryArticleLists';
 import { Article, ResponseArticleType } from 'articles/types';
 import axios from 'axios';
 import { CategoryType } from 'categories/types';
+import NotFoundTitle from 'components/NotFoundTitle';
 import { endpoint } from 'config';
 import { formatDistanceToNow } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import React, { useEffect, useRef, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { setCategory } from 'store/ducks/categorySlice';
 import { useAppDispatch } from 'store/hooks';
 
@@ -17,28 +18,91 @@ import CategoryArticlesHeader from '../components/CategoryArticlesHeader';
 const CategoryFilterableArticles = () => {
   const [filterInput, setFilterInput] = useState<string>('');
   const [articleItems, setArticleItems] = useState<Article[]>([]);
-  const { categoryName } = useParams();
-  const [searchParams] = useSearchParams();
-  const articleGenre = searchParams.get('tab');
   const [isLoading, setIsLoading] = useState(false);
-  const [page, setPage] = useState(1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const params = useParams();
+
+  const categoryTable = [
+    'ui',
+    'design',
+    'react',
+    'github',
+    'javascript',
+    'rails',
+    'aws',
+    'docker',
+    'terraform',
+    'nuxtjs',
+    'game',
+    'まとめ',
+    'vue',
+    'netlify',
+    'gatsby',
+    'graphql',
+    'php',
+    'flutter',
+    'heroku',
+    'nestjs',
+    'python',
+    'スタートアップ',
+    'ruby',
+    'bot',
+    'googlemapsapi',
+    'gas',
+    'ポエム',
+    'nextjs',
+    'vercel',
+    'chrome',
+    'svg',
+    'typescript',
+    'django',
+    'gcp',
+    'laravel',
+    '機械学習',
+    'firebase',
+    'nodejs',
+    '英語',
+    '失敗談',
+    'swift',
+    'アイデア',
+    'csharp',
+    'azure',
+    'jquery',
+    'unity',
+    'marketing',
+    'pwa',
+    'circleci',
+    'twitter',
+    'css',
+    'amplify',
+    'fargate',
+    'ecs',
+    'nocode',
+    'android',
+    'springboot',
+    'mysql',
+    'ios',
+    'firestore',
+    'go',
+    'threejs',
+    'stripe',
+    'others',
+    'linebot',
+  ];
 
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    setFilterInput('');
     setIsLoading(true);
-    setPage(1);
     const fetchArticles = async () => {
       const res = await axios.get<ResponseArticleType>(
-        `${endpoint}/${categoryName}/articles?tab=${articleGenre}`
+        `${endpoint}/${params.categoryName}/articles?tab=${params.tab}`
       );
       return res.data;
     };
     const fetchCategory = async () => {
       const res = await axios.get<{ data: CategoryType }>(
-        `${endpoint}/categories/${categoryName}`
+        `${endpoint}/categories/${params.categoryName}`
       );
 
       return res.data.data;
@@ -92,43 +156,45 @@ const CategoryFilterableArticles = () => {
         })
       );
     });
-  }, [categoryName, articleGenre, dispatch]);
+  }, [params.categoryName, params.tab, dispatch]);
 
-  return (
-    <>
-      <CategoryArticlesHeader />
-      <Space h="lg" />
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          setPage(1);
-          if (inputRef.current?.value) {
-            setFilterInput(inputRef.current.value);
-          } else {
-            setFilterInput('');
-          }
-        }}
-      >
-        <TextInput
-          icon={<IconSearch size={18} stroke={1.5} />}
-          radius="lg"
-          size="sm"
-          placeholder="キーワードを入力..."
-          ref={inputRef}
+  const categoryFlag = categoryTable.includes(params.categoryName || '');
+  const tabFlag = params.tab === 'all' || params.tab === 'popular';
+  if (categoryFlag && tabFlag) {
+    return (
+      <>
+        <CategoryArticlesHeader />
+        <Space h="lg" />
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (inputRef.current?.value) {
+              setFilterInput(inputRef.current.value);
+            } else {
+              setFilterInput('');
+            }
+          }}
+        >
+          <TextInput
+            icon={<IconSearch size={18} stroke={1.5} />}
+            radius="lg"
+            size="sm"
+            placeholder="キーワードを入力..."
+            ref={inputRef}
+          />
+        </form>
+        <Space h="lg" />
+        <CategoryArticleLists
+          leftGenre="すべての記事"
+          rightGenre="人気記事"
+          articleItems={articleItems}
+          isLoading={isLoading}
+          filterInput={filterInput}
         />
-      </form>
-      <Space h="lg" />
-      <ArticleLists
-        leftGenre="すべての記事"
-        rightGenre="人気記事"
-        articleItems={articleItems}
-        isLoading={isLoading}
-        filterInput={filterInput}
-        page={page}
-        setPage={setPage}
-      />
-    </>
-  );
+      </>
+    );
+  }
+  return <NotFoundTitle />;
 };
 
 export default CategoryFilterableArticles;

--- a/src/features/articles/containers/FilterableArticles.tsx
+++ b/src/features/articles/containers/FilterableArticles.tsx
@@ -2,11 +2,12 @@ import { TextInput } from '@mantine/core';
 import { IconSearch } from '@tabler/icons';
 import { Article, ResponseArticleType } from 'articles/types';
 import axios, { AxiosResponse } from 'axios';
+import NotFoundTitle from 'components/NotFoundTitle';
 import { endpoint } from 'config';
 import { formatDistanceToNow } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import React, { useEffect, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import ArticleLists from '../components/ArticleLists';
 
@@ -14,17 +15,15 @@ const FilterableArticles = () => {
   const [filterInput, setFilterInput] = useState<string>('');
   const [articleItems, setArticleItems] = useState<Article[]>([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [searchParams] = useSearchParams();
-  const articleGenre = searchParams.get('tab') || '';
+  const params = useParams();
+  const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [page, setPage] = useState(1);
 
   useEffect(() => {
-    setFilterInput('');
     setIsLoading(true);
     const fetchArticles = async () => {
       const res: AxiosResponse<ResponseArticleType> = await axios.get(
-        `${endpoint}/articles?tab=${articleGenre}`
+        `${endpoint}/articles?tab=${params.tab}`
       );
 
       return res.data;
@@ -66,41 +65,42 @@ const FilterableArticles = () => {
         alert('記事情報の取得に失敗しました');
       })
       .finally(() => setIsLoading(false));
-  }, [articleGenre]);
+  }, [params.tab]);
 
-  return (
-    <>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          setPage(1);
-          if (inputRef.current?.value) {
-            setFilterInput(inputRef.current.value);
-          } else {
-            setFilterInput('');
-          }
-        }}
-      >
-        <TextInput
-          icon={<IconSearch size={18} stroke={1.5} />}
-          radius="lg"
-          size="sm"
-          placeholder="キーワードを入力..."
-          ref={inputRef}
+  if (params.tab === 'all' || params.tab === 'popular') {
+    return (
+      <>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (inputRef.current?.value) {
+              setFilterInput(inputRef.current.value);
+            } else {
+              setFilterInput('');
+            }
+            navigate(`/articles/${params.tab}`);
+          }}
+        >
+          <TextInput
+            icon={<IconSearch size={18} stroke={1.5} />}
+            radius="lg"
+            size="sm"
+            placeholder="キーワードを入力..."
+            ref={inputRef}
+          />
+        </form>
+        <br />
+        <ArticleLists
+          leftGenre="すべての記事"
+          rightGenre="人気記事"
+          articleItems={articleItems}
+          filterInput={filterInput}
+          isLoading={isLoading}
         />
-      </form>
-      <br />
-      <ArticleLists
-        leftGenre="すべての記事"
-        rightGenre="人気記事"
-        articleItems={articleItems}
-        filterInput={filterInput}
-        isLoading={isLoading}
-        page={page}
-        setPage={setPage}
-      />
-    </>
-  );
+      </>
+    );
+  }
+  return <NotFoundTitle />;
 };
 
 export default FilterableArticles;

--- a/src/features/articles/types/index.ts
+++ b/src/features/articles/types/index.ts
@@ -1,5 +1,4 @@
 import { Category, CategoryType } from 'categories/types';
-import { Dispatch, SetStateAction } from 'react';
 import { BaseEntity } from 'types';
 
 export type Article = {
@@ -20,9 +19,7 @@ export type ArticleListsProps = {
   filterInput: string;
   isLoading: boolean;
   leftGenre: string;
-  page: number;
   rightGenre: string;
-  setPage: Dispatch<SetStateAction<number>>;
 };
 
 export type ArticleType = {

--- a/src/features/categories/components/CategoryItem.tsx
+++ b/src/features/categories/components/CategoryItem.tsx
@@ -42,7 +42,7 @@ const CategoryItem = ({ id, title, image, path }: Category) => {
             path,
           })
         );
-        navigate(`/categories/${path}`);
+        navigate(`/categories/${path}/all`);
       }}
     >
       <Image src={image} height={50} fit="contain" />

--- a/src/features/users/components/UserArticleLists.tsx
+++ b/src/features/users/components/UserArticleLists.tsx
@@ -10,7 +10,12 @@ import {
 import ArticleItem from 'articles/components/ArticleItem';
 import { ArticleListsProps } from 'articles/types';
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import {
+  useLocation,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from 'react-router-dom';
 
 import { useMediaQuery } from '../../../lib/mantine/useMediaQuery';
 
@@ -20,64 +25,43 @@ const UserArticleLists = ({
   leftGenre,
   rightGenre,
   articleItems,
-  filterInput,
   isLoading,
-  page,
-  setPage,
-}: ArticleListsProps) => {
+}: Omit<ArticleListsProps, 'filterInput'>) => {
   const largerThanSm = useMediaQuery('sm');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const articleGenre = searchParams.get('tab') || 'all';
+  const articlePage = parseInt(searchParams.get('page') || '1');
+  const params = useParams();
+
   const { hash, pathname } = useLocation();
 
   const [currentArticleItems, setCurrentArticleItems] = useState(
     articleItems.slice(0, ITEMS_PAGE_SIZE)
   );
 
-  const pageCount = Math.ceil(
-    articleItems.filter((articleItem) =>
-      new RegExp(filterInput, 'i').test(articleItem.title)
-    ).length / ITEMS_PAGE_SIZE
-  );
+  const pageCount = Math.ceil(articleItems.length / ITEMS_PAGE_SIZE);
 
   useEffect(() => {
     if (!hash) {
       window.scrollTo(0, 0);
     }
-    const filterArticleItems = articleItems.filter((articleItem) =>
-      new RegExp(filterInput, 'i').test(articleItem.title)
-    );
-    const from = (page - 1) * ITEMS_PAGE_SIZE;
+    const from = (articlePage - 1) * ITEMS_PAGE_SIZE;
     const to = from + ITEMS_PAGE_SIZE;
-    setCurrentArticleItems(filterArticleItems.slice(from, to));
-  }, [page, articleItems, filterInput, hash, pathname]);
+    setCurrentArticleItems(articleItems.slice(from, to));
+  }, [articlePage, articleItems, hash, pathname]);
 
   return (
     <Card radius="md">
-      <Tabs value={articleGenre}>
+      <Tabs
+        value={params.tab}
+        onTabChange={(value) => {
+          navigate(`/dashboards/${value}`);
+        }}
+      >
         <Tabs.List className="flex justify-around">
-          <Tabs.Tab value="all" onClick={() => navigate('/dashboards')}>
-            すべての記事
-          </Tabs.Tab>
-          <Tabs.Tab
-            value="likes"
-            onClick={() => {
-              setPage(1);
-              navigate(`${pathname}?tab=likes`);
-            }}
-          >
-            {leftGenre}
-          </Tabs.Tab>
-          <Tabs.Tab
-            value="bookmarks"
-            onClick={() => {
-              setPage(1);
-              navigate(`${pathname}?tab=bookmarks`);
-            }}
-          >
-            {rightGenre}
-          </Tabs.Tab>
+          <Tabs.Tab value="all">すべての記事</Tabs.Tab>
+          <Tabs.Tab value="likes">{leftGenre}</Tabs.Tab>
+          <Tabs.Tab value="bookmarks">{rightGenre}</Tabs.Tab>
         </Tabs.List>
       </Tabs>
       {isLoading ? (
@@ -92,7 +76,13 @@ const UserArticleLists = ({
             ))}
           </SimpleGrid>
           <Card className="mt-10 flex items-center justify-center">
-            <Pagination total={pageCount} onChange={setPage} page={page} />
+            <Pagination
+              total={pageCount}
+              onChange={(nextPage) => {
+                navigate(`${pathname}?page=${nextPage}`);
+              }}
+              page={articlePage}
+            />
           </Card>
         </>
       ) : (
@@ -106,7 +96,13 @@ const UserArticleLists = ({
             ))}
           </SimpleGrid>
           <Card className="mt-10 flex items-center justify-center">
-            <Pagination total={pageCount} onChange={setPage} page={page} />
+            <Pagination
+              total={pageCount}
+              onChange={(nextPage) => {
+                navigate(`${pathname}?page=${nextPage}`);
+              }}
+              page={articlePage}
+            />
           </Card>
         </>
       )}

--- a/src/features/users/containers/MyArticles.tsx
+++ b/src/features/users/containers/MyArticles.tsx
@@ -6,15 +6,13 @@ import { formatDistanceToNow } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { getAuth } from 'firebase/auth';
 import React, { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import UserArticleLists from 'users/components/UserArticleLists';
 
 const MyArticles = () => {
-  const [page, setPage] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [articleItems, setArticleItems] = useState<Article[]>([]);
-  const [searchParams] = useSearchParams();
-  const articleGenre = searchParams.get('tab') || '';
+  const params = useParams();
 
   useEffect(() => {
     const fetchBookmarks = async () => {
@@ -68,7 +66,7 @@ const MyArticles = () => {
 
     setIsLoading(true);
 
-    switch (articleGenre) {
+    switch (params.tab) {
       case 'bookmarks':
         fetchBookmarks()
           .then((data) => {
@@ -187,7 +185,7 @@ const MyArticles = () => {
           .finally(() => setIsLoading(false));
         break;
     }
-  }, [articleGenre]);
+  }, [params.tab]);
 
   return (
     <>
@@ -195,10 +193,7 @@ const MyArticles = () => {
         leftGenre="いいねした記事"
         rightGenre="ブックマークした記事"
         articleItems={articleItems}
-        filterInput=""
         isLoading={isLoading}
-        page={page}
-        setPage={setPage}
       />
     </>
   );

--- a/src/features/users/routes/UserArticles.tsx
+++ b/src/features/users/routes/UserArticles.tsx
@@ -1,16 +1,22 @@
 import { Space } from '@mantine/core';
+import NotFoundTitle from 'components/NotFoundTitle';
 import React from 'react';
+import { useParams } from 'react-router-dom';
 import MyArticles from 'users/containers/MyArticles';
 import UserInfo from 'users/containers/UserInfo';
 
 const UserArticles = () => {
-  return (
-    <>
-      <UserInfo />
-      <Space h="lg" />
-      <MyArticles />
-    </>
-  );
+  const params = useParams();
+  if (params.tab === 'all' || params.tab === 'popular') {
+    return (
+      <>
+        <UserInfo />
+        <Space h="lg" />
+        <MyArticles />
+      </>
+    );
+  }
+  return <NotFoundTitle />;
 };
 
 export default UserArticles;

--- a/src/routes/NotFound.tsx
+++ b/src/routes/NotFound.tsx
@@ -9,6 +9,7 @@ import {
 import FooterLinks from 'components/Footer';
 import HeaderAction from 'components/HeaderAction';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { selectUser } from 'store/ducks/userSlice';
 import { useAppSelector } from 'store/hooks';
 
@@ -89,6 +90,7 @@ const NotFound = () => {
   const { classes } = useStyles();
   const user = useAppSelector(selectUser);
   const isLogin = user.uid ? true : false;
+  const navigate = useNavigate();
   return (
     <>
       <HeaderAction {...{ links, isLogin }} />
@@ -108,7 +110,7 @@ const NotFound = () => {
             address, or the page has been moved to another URL.
           </Text>
           <Group position="center">
-            <Button variant="subtle" size="md">
+            <Button variant="subtle" size="md" onClick={() => navigate('/')}>
               Take me back to home page
             </Button>
           </Group>

--- a/src/routes/RouteAuthGuard.tsx
+++ b/src/routes/RouteAuthGuard.tsx
@@ -30,15 +30,15 @@ export const RouteAuthGuard = ({
               </Container>
             </UserLayout>
           );
-        } else if (location.pathname === '/dashboards') {
+        } else if (location.pathname === '/onboarding') {
           return (
-            <Container className="flex items-center justify-center py-60">
+            <Container className="flex h-screen items-center justify-center">
               <Loader />
             </Container>
           );
         } else {
           return (
-            <Container className="flex h-screen items-center justify-center">
+            <Container className="flex items-center justify-center py-60">
               <Loader />
             </Container>
           );
@@ -53,23 +53,20 @@ export const RouteAuthGuard = ({
     if (location.pathname === '/profile') {
       return (
         <UserLayout>
-          {/* <Center>
-            <Loader />
-          </Center> */}
           <Container className="flex items-center justify-center py-60">
             <Loader />
           </Container>
         </UserLayout>
       );
-    } else if (location.pathname === '/dashboards') {
+    } else if (location.pathname === '/onboarding') {
       return (
-        <Container className="flex items-center justify-center py-60">
+        <Container className="flex h-screen items-center justify-center">
           <Loader />
         </Container>
       );
     } else {
       return (
-        <Container className="flex h-screen items-center justify-center">
+        <Container className="flex items-center justify-center py-60">
           <Loader />
         </Container>
       );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,10 +3,11 @@ import FilterableArticles from 'articles/containers/FilterableArticles';
 import RegisterForm from 'auth/components/RegisterForm';
 import LoginImage from 'auth/containers/LoginImage';
 import FilterableCategoryLists from 'categories/containers/FilterableCategoryLists';
+import NotFoundTitle from 'components/NotFoundTitle';
 import MainLayout from 'Layout/MainLayout';
 import { useFirebaseAuth } from 'lib/auth/firebaseAuth';
 import React, { useEffect } from 'react';
-import { Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import Home from 'routes/Home';
 import { RouteAuthGuard } from 'routes/RouteAuthGuard';
 import UserArticles from 'users/routes/UserArticles';
@@ -27,14 +28,20 @@ const AppRoutes = () => {
   return (
     <Routes>
       <Route path="articles" element={<MainLayout />}>
-        <Route index element={<FilterableArticles />} />
+        <Route index element={<Navigate to="/" replace />} />
+        <Route path=":tab" element={<FilterableArticles />} />
+        {/* <Route index element={<FilterableArticles />} /> */}
         {/* <Route path=":articleId" element={<ArticleProfile />} /> */}
-        {/* <Route path="*" element={<NotFoundTitle />} /> */}
+        <Route path="*" element={<NotFoundTitle />} />
       </Route>
       <Route path="categories" element={<MainLayout />}>
         <Route index element={<FilterableCategoryLists />} />
-        <Route path=":categoryName" element={<CategoryFilterableArticles />} />
-        {/* <Route path="*" element={<NotFoundTitle />} /> */}
+        <Route path=":categoryName">
+          <Route index element={<Navigate to="/categories" replace />} />
+          <Route path=":tab" element={<CategoryFilterableArticles />} />
+          <Route path="*" element={<NotFoundTitle />} />
+        </Route>
+        <Route path="*" element={<NotFoundTitle />} />
       </Route>
       <Route
         path="profile"
@@ -43,12 +50,14 @@ const AppRoutes = () => {
         }
       />
       <Route path="dashboards" element={<MainLayout />}>
+        <Route index element={<Navigate to="/" replace />} />
         <Route
-          index
+          path=":tab"
           element={
             <RouteAuthGuard component={<UserArticles />} redirect="/login" />
           }
         />
+        <Route path="*" element={<NotFoundTitle />} />
       </Route>
       <Route
         path="onboarding"
@@ -56,7 +65,6 @@ const AppRoutes = () => {
       />
       <Route path="login" element={<LoginImage />} />
       <Route path="/" element={<Home />} />
-      {/* <Route path="*" element={<Navigate to="/" replace />} /> */}
       <Route path="*" element={<NotFound />} />
     </Routes>
   );


### PR DESCRIPTION
## Issue

#74 

## 変更の概要

ページネーションの値をクエリパラメータとして含めることで、戻る・進むボタンでページ値を保持できるようにする

## なぜこの変更をするのか

ユーザーが戻る・進むボタンを押したときに、以前見ていたページに戻れないことを防ぐため